### PR TITLE
Fix README hockey badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Comprehensive Database for Collectors and Developers
 
-[![Baseball Cards Indexed](.github/badge/baseball.svg)](.github/badge/baseball.svg) [![Football Cards Indexed](.github/badge/football.svg)](.github/badge/football.svg) [![Basketball Cards Indexed](.github/badge/basketball.svg)](.github/badge/basketball.svg) [![Hockey Cards Indexed](.github/badge/hockey.svg)](badge/hockey.svg)
+[![Baseball Cards Indexed](.github/badge/baseball.svg)](.github/badge/baseball.svg) [![Football Cards Indexed](.github/badge/football.svg)](.github/badge/football.svg) [![Basketball Cards Indexed](.github/badge/basketball.svg)](.github/badge/basketball.svg) [![Hockey Cards Indexed](.github/badge/hockey.svg)](.github/badge/hockey.svg)
 [![Baseball Cards Indexed Graph](.github/graph/baseball_bar.png)](.github/graph/baseball_bar.png)
 
 Welcome to the Sports Cards JSON Repository, your ultimate destination for exploring sports card data in a structured and open-source format. This repository features comprehensive datasets for baseball cards, football cards, basketball cards, and hockey cards in a developer-friendly JSON format. Collectors, developers, and enthusiasts can use this resource to power their projects such as:


### PR DESCRIPTION
## Summary
- fix invalid hockey badge link in README

## Testing
- `python3 scripts/validate-json-data.py categories/baseball/1990/1990-Topps.json`
- `python3 scripts/build-parquet.py` *(fails unless optional dependencies installed; installed pandas and pyarrow successfully)*

------
https://chatgpt.com/codex/tasks/task_e_686efe394f3483308382cfe902bc818f